### PR TITLE
Prevent kubectl override of exec plugin credentials.

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,12 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/Bisnode/kubectl-login/handler"
-	"github.com/Bisnode/kubectl-login/util"
-	"github.com/dgrijalva/jwt-go"
-	"github.com/skratchdot/open-golang/open"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/clientcmd/api"
 	"log"
 	"net"
 	"net/http"
@@ -19,6 +13,13 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/Bisnode/kubectl-login/handler"
+	"github.com/Bisnode/kubectl-login/util"
+	"github.com/dgrijalva/jwt-go"
+	"github.com/skratchdot/open-golang/open"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
 )
 
 const version = "1.0.0"
@@ -127,8 +128,8 @@ func currentToken(clientCfg *api.Config) string {
 		fmt.Println("No current-context set - run 'kubectl login --init' to initialize context")
 		os.Exit(1)
 	}
-
-	return clientCfg.AuthInfos[clientCfg.CurrentContext].Token
+	// Note that absence of a token is not an error here but an empty string is returned
+	return util.ReadToken(clientCfg.CurrentContext)
 }
 
 func main() {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -2,9 +2,10 @@ package util
 
 import (
 	"fmt"
-	"github.com/dgrijalva/jwt-go"
 	"reflect"
 	"testing"
+
+	"github.com/dgrijalva/jwt-go"
 )
 
 func TestExtractsSingleTeamFromListOfGroups(t *testing.T) {


### PR DESCRIPTION
This is done by never storing the retrieved credentials in `KUBECONFIG` in the first place. Another bonus of using this approach is that it's possible to wipe the `~/.kube/config` file, restore it and
still have the previously retrieved credential to be used.

Quick fix for [issue #4](https://github.com/Bisnode/kubectl-login/issues/4) which in turn is a workaround for [this issue](https://github.com/kubernetes/kubernetes/issues/87369).