### PR TITLE
Force exit on timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2020-05-29
+### Changed
+- kubectl-login will now exit after 10 minutes of idling. This in order to prevent the program from staying in the 
+  background if left unattended.
+- Added a sleep in the main loop to avoid hogging the CPU while active.
+
 ## [1.1.0] - 2020-02-12
 ### Changed
 - Token is now stored outside of `KUBECONFIG` to avoid it being sent when expired, as described in the kubernetes issue

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/Bisnode/kubectl-login/util"
@@ -90,8 +91,8 @@ func (h *IDTokenWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	}
 
 	if !h.ExecCredentialMode {
-		fmt.Println(fmt.Sprintf(
-			"Authenticated for context %v. Token valid until %v.", h.ClientCfg.CurrentContext, exp))
+		_, _ = fmt.Fprintf(os.Stdout,
+			"Authenticated for context %v. Token valid until %v.\n", h.ClientCfg.CurrentContext, exp)
 	}
 
 	// Return control to shell at this point


### PR DESCRIPTION
- Force exit after 10 minutes of (in)activity in order to avoid staying in the background forever on idle as some people reported.
- Add a sleep on the main loop to avoid hogging CPU while waiting for token.
- Fix linter warnings about the use of fmt.Print(fmt.Sprint(..))

Closes #6.