### PR TITLE
GH-11-Big-Sur-Sour

### DIFF
--- a/main.go
+++ b/main.go
@@ -212,7 +212,7 @@ func main() {
 		"client_id":     "kubectl-login",
 		"response_type": "id_token",
 		"response_mode": "form_post",
-		"scope":         "openid email tbac",
+		"scope":         "openid%20email%20tbac",
 		"nonce":         nonce,
 	}
 	authorizeRequestURL := issuer.AuthorizeEndpoint + "?"
@@ -230,7 +230,7 @@ func main() {
 		err = open.RunWith(authorizeRequestURL, preferredBrowser)
 	}
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Failed opening web browser: %v", err)
 	}
 
 	idTokenHandler := &handler.IDTokenWebhookHandler{


### PR DESCRIPTION
URL escape whitespace in scope as `open` on Mac OS Big Sur no longer recognized it as a URL.

Tested only on Mac OS Big Sur yet, so if someone can help me test this on Linux and Windows I'd appreciate it.

Closes #11 